### PR TITLE
Refactor SSH key handling in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,44 +73,43 @@ jobs:
           ls -lah
           tar -tzf dist.tar.gz | head -n 20
   
-      - name: Prepare SSH key
+      - name: Write SSH key
+        id: write-key
         run: |
           set -euo pipefail
-          mkdir -p ~/.ssh
-          # write multiline PEM correctly and strip Windows carriage returns
-          printf "%s" "${{ secrets.EC2_SSH_KEY }}" | tr -d '\r' > ~/.ssh/StrandsKey.pem
-          chmod 600 ~/.ssh/StrandsKey.pem
-          ls -lah ~/.ssh
-          head -n 2 ~/.ssh/StrandsKey.pem
-
+          echo "Writing EC2 PEM key to file..."
+          echo "${{ secrets.EC2_SSH_KEY }}" | tr -d '\r' > $GITHUB_WORKSPACE/StrandsKey.pem
+          chmod 600 $GITHUB_WORKSPACE/StrandsKey.pem
+          ls -lah $GITHUB_WORKSPACE
+          head -n 2 $GITHUB_WORKSPACE/StrandsKey.pem
+  
       - name: Prep remote dirs
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ec2-3-134-137-100.us-east-2.compute.amazonaws.com
           username: ubuntu
-          key_path: ~/.ssh/StrandsKey.pem
+          key_path: ${{ github.workspace }}/StrandsKey.pem
           script: |
             set -euxo pipefail
             BASE=${{ env.REMOTE_DIR }}
             mkdir -p "$BASE/releases" "$BASE/current"
             chown -R ubuntu:ubuntu "$BASE"
   
-
       - name: Upload to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ec2-3-134-137-100.us-east-2.compute.amazonaws.com
           username: ubuntu
-          key_path: ~/.ssh/StrandsKey.pem
+          key_path: ${{ github.workspace }}/StrandsKey.pem
           source: ./dist.tar.gz
           target: ${{ env.REMOTE_DIR }}/releases/
-
+  
       - name: Activate release on EC2
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ec2-3-134-137-100.us-east-2.compute.amazonaws.com
           username: ubuntu
-          key_path: ~/.ssh/StrandsKey.pem
+          key_path: ${{ github.workspace }}/StrandsKey.pem   # 👈 consistent path
           script: |
             set -euo pipefail
             BASE=${{ env.REMOTE_DIR }}


### PR DESCRIPTION
Updated the path for the SSH key to use the GitHub workspace directory for consistency across steps.